### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/ics.js
+++ b/lib/ics.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 
 var _ = require('lodash');
 var moment = require('moment-timezone');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var DEFAULTS = {
   filename: 'event'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   "dependencies": {
     "lodash": "^4.16.4",
     "moment-timezone": "^0.5.6",
-    "node-uuid": "^1.4.7"
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.