### PR TITLE
Add support for custom uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var ICS = require('ics');
 var ics = new ICS();
 
 ics.buildEvent({
+  uid: 'abc123', // (optional)
   start: '2016-05-30 06:50',
   end: '2016-05-30 15:00',
   title: 'Bolder Boulder',

--- a/lib/ics.js
+++ b/lib/ics.js
@@ -59,9 +59,9 @@ function buildEvent(attributes) {
     return file;
   }
 
-  function generateUID() {
-    if(attributes.uid) {
-      return 'UID:' + attributes.uid;
+  function generateUID(uid) {
+    if(uid) {
+      return 'UID:' + uid;
     }
     return 'UID:' + uuid.v1();
   }

--- a/lib/ics.js
+++ b/lib/ics.js
@@ -26,7 +26,7 @@ function buildEvent(attributes) {
     .concat(defineTimeZone(attributes))
     .concat([
       'BEGIN:VEVENT',
-      generateUID(),
+      generateUID(attributes.uid),
       'DTSTAMP:' + generateDateTimeStamp(),
       formatDTSTART(attributes.start, attributes.timeZone),
       formatDTEND(attributes.start, attributes.end, attributes.timeZone, attributes.timeZoneEnd),
@@ -60,6 +60,9 @@ function buildEvent(attributes) {
   }
 
   function generateUID() {
+    if(attributes.uid) {
+      return 'UID:' + attributes.uid;
+    }
     return 'UID:' + uuid.v1();
   }
 

--- a/lib/ics.js
+++ b/lib/ics.js
@@ -80,15 +80,18 @@ function buildEvent(attributes) {
     }
 
     if (tz) {
+      // Form #3: DATE WITH LOCAL TIME AND TIME ZONE REFERENCE
       return 'DTSTART;TZID=' + tz + ':' + moment(string).format('YYYYMMDDTHHmm00');
     }
 
-    if (isDateTime(string) && moment.parseZone(string).utcOffset() === 0) {
+    if (isDateTime(string) && moment.parseZone(string).utcOffset() === 0 && !isUTC(string)) {
+      // Form #1: DATE WITH LOCAL TIME
       return 'DTSTART:' + moment(string).format('YYYYMMDDTHHmm00');
     }
 
     if (isDateTime(string)) {
-      return moment(string).format('YYYYMMDDTHHmm00') + 'Z';
+      // Form #2: DATE WITH UTC TIME
+      return 'DTSTART:' + moment.utc(string).format('YYYYMMDDTHHmm00') + 'Z';
     }
 
     return 'DTSTART;VALUE=DATE:' + moment(string).format('YYYYMMDD');
@@ -133,6 +136,10 @@ function buildEvent(attributes) {
     return ['T', ' '].some(function (char) {
       return string.search(char) !== -1;
     });
+  }
+
+  function isUTC(string) {
+    return string[string.length - 1] === 'Z';
   }
 
   function generateDateTimeStamp() {

--- a/test/ics.spec.js
+++ b/test/ics.spec.js
@@ -100,6 +100,11 @@ describe('ICS', function() {
         .to.be.greaterThan(-1);
     });
 
+    it('sets an absolute, DATE-TIME-typed DTSTART when passed a DATE-TIME-typed start param with a UTC designator and no timezone', function() {
+      expect(ics.buildEvent({start: '2017-09-25T02:30:00.000Z'}).search('DTSTART:20170925T023000Z\r\n'))
+        .to.be.greaterThan(-1);
+    });
+
     it('sets a floating, DATE-TIME-typed DTEND with same value as DTSTART when passed a DATE-TIME-typed start param with neither a UTC designator nor a timezone', function() {
       expect(ics.buildEvent({start: '2017-09-25 02:30:00'}).search('DTEND:20170925T023000\r\n'))
         .to.be.greaterThan(-1);

--- a/test/ics.spec.js
+++ b/test/ics.spec.js
@@ -145,6 +145,12 @@ describe('ICS', function() {
       expect(evnt.search('ATTENDEE;CN=Dad:mailto:dad@example.com')).to.be.greaterThan(-1);
       expect(evnt.search('ATTENDEE;CN=Mom:mailto:mom@example.com')).to.be.greaterThan(-1);
     });
+
+    it('sets uid if one is provided', function() {
+      var uid = 'some-event-uid';
+      var evnt = ics.buildEvent({uid: uid});
+      expect(evnt.search('UID:' + uid)).to.be.greaterThan(-1);
+    });
   });
 
   describe('getDestination()', function() {


### PR DESCRIPTION
- Add support for a user generated UID. In order to cancel a previously created calendar event, you'll need to reference the UID.