### PR TITLE
Reimplement organizer field

### DIFF
--- a/lib/ics.js
+++ b/lib/ics.js
@@ -38,6 +38,7 @@ function buildEvent(attributes) {
       formatGeo(attributes.geo)
     ])
     .concat(formatAttendees(attributes))
+    .concat(formatOrganizer(attributes))
     .concat(formatCategories(attributes))
     .concat(formatAttachments(attributes))
     .concat(['END:VEVENT', 'END:VCALENDAR'])).join('\r\n');
@@ -171,6 +172,17 @@ function buildEvent(attributes) {
         }
         return null;
       });
+    }
+
+    return null;
+  }
+  
+  function formatOrganizer(attributes) {
+    if (attributes.organizer) {
+      if (attributes.organizer.name && attributes.organizer.email) {
+        return 'ORGANIZER;CN=' + attributes.organizer.name + ':mailto:' + attributes.organizer.email;
+      }
+      return null;
     }
 
     return null;

--- a/test/ics.spec.js
+++ b/test/ics.spec.js
@@ -153,7 +153,7 @@ describe('ICS', function() {
     
     it('adds one organizer', function() {
       var evnt = ics.buildEvent({ organizer: { name: 'Grandpa', email: 'grandpa@example.com' } });
-      expect(evnt.search('ATTENDEE;CN=Grandpa:mailto:grandpa@example.com')).to.be.greaterThan(-1);
+      expect(evnt.search('ORGANIZER;CN=Grandpa:mailto:grandpa@example.com')).to.be.greaterThan(-1);
     });
 
     it('sets uid if one is provided', function() {

--- a/test/ics.spec.js
+++ b/test/ics.spec.js
@@ -152,7 +152,7 @@ describe('ICS', function() {
     });
     
     it('adds one organizer', function() {
-      var evnt = ics.buildEvent({ organizer: [{ name: 'Grandpa', email: 'grandpa@example.com' }] });
+      var evnt = ics.buildEvent({ organizer: { name: 'Grandpa', email: 'grandpa@example.com' } });
       expect(evnt.search('ATTENDEE;CN=Grandpa:mailto:grandpa@example.com')).to.be.greaterThan(-1);
     });
 

--- a/test/ics.spec.js
+++ b/test/ics.spec.js
@@ -150,6 +150,11 @@ describe('ICS', function() {
       expect(evnt.search('ATTENDEE;CN=Dad:mailto:dad@example.com')).to.be.greaterThan(-1);
       expect(evnt.search('ATTENDEE;CN=Mom:mailto:mom@example.com')).to.be.greaterThan(-1);
     });
+    
+    it('adds one organizer', function() {
+      var evnt = ics.buildEvent({ organizer: [{ name: 'Grandpa', email: 'grandpa@example.com' }] });
+      expect(evnt.search('ATTENDEE;CN=Grandpa:mailto:grandpa@example.com')).to.be.greaterThan(-1);
+    });
 
     it('sets uid if one is provided', function() {
       var uid = 'some-event-uid';


### PR DESCRIPTION
Reimplements the organizer field. Only allows one organizer as per [RFC 5545](https://tools.ietf.org/html/rfc5545#page-111). Fixes #23.