### PR TITLE
Updated README to reflect productId & uid options

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The following properties are accepted:
 | attendees     | Persons invited to the event | `[{ name: 'Mo', email: 'mo@foo.com'}, { name: 'Bo', email: 'bo@bar.biz' }]`
 | categories    | Categories associated with the event | `['hacknight', 'stout month']`
 | alarms        | Alerts that can be set to trigger before, during, or after the event | `{ action: 'DISPLAY', trigger: [2000, 1, 4, 18, 30] }`
+| productId     | Product which created ics, `PRODID` field | `'adamgibbons/ics'`
+| uid           | Universal unique id for event, produced by default with `uuid/v1`.  **Warning:** This value must be **globally unique**.  It is recommended that it follow the [RFC 822 addr-spec](https://www.w3.org/Protocols/rfc822/) (i.e. `localpart@domain`).  Including the `@domain` half is a good way to ensure uniqueness. | `'28021620-be61-11e7-be87-5f3ab42f0785'`
 
 #### `callback`
 


### PR DESCRIPTION
I made sure to include a warning about specifying your own _id.  My co-founder spent a few hours trying to modify the output with a regex because he didn't realize that you could directly pass in a `uid`.  Seemed worth documenting.