### PR TITLE
Fold lines longer than 75 characters to address #65

### DIFF
--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -5,7 +5,8 @@ import {
     setDate,
     setDescription,
     setGeolocation,
-    formatDuration
+    formatDuration,
+    foldLine
 } from '../utils'
 
 export default function formatEvent (attributes = {}) {
@@ -33,23 +34,23 @@ export default function formatEvent (attributes = {}) {
     icsFormat += 'BEGIN:VCALENDAR\r\n'
     icsFormat += 'VERSION:2.0\r\n'
     icsFormat += 'CALSCALE:GREGORIAN\r\n'
-    icsFormat += `PRODID:${productId}\r\n`
+    icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
     icsFormat += 'BEGIN:VEVENT\r\n'
     icsFormat += `UID:${uid}\r\n`
-    icsFormat += `SUMMARY:${title}\r\n`
+    icsFormat += foldLine(`SUMMARY:${title}`) + '\r\n'
     icsFormat += `DTSTAMP:${timestamp}\r\n`
     icsFormat += `DTSTART:${setDate(start, startType)}\r\n`
     icsFormat += end ? `DTEND:${setDate(end, startType)}\r\n` : ''
-    icsFormat += description ? `DESCRIPTION:${setDescription(description)}\r\n` : ''
-    icsFormat += url ? `URL:${url}\r\n` : ''
-    icsFormat += geo ? `GEO:${setGeolocation(geo)}\r\n` : ''
-    icsFormat += location ? `LOCATION:${location}\r\n` : ''
-    icsFormat += status ? `STATUS:${status}\r\n` : ''
-    icsFormat += categories ? `CATEGORIES:${categories}\r\n` : ''
-    icsFormat += organizer ? `ORGANIZER;${setOrganizer(organizer)}\r\n` : ''
+    icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
+    icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
+    icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''
+    icsFormat += location ? (foldLine(`LOCATION:${location}`) + '\r\n') : ''
+    icsFormat += status ? (foldLine(`STATUS:${status}`) + '\r\n') : ''
+    icsFormat += categories ? (foldLine(`CATEGORIES:${categories}`) + '\r\n') : ''
+    icsFormat += organizer ? (foldLine(`ORGANIZER;${setOrganizer(organizer)}`) + '\r\n') : ''
     if (attendees) {
       attendees.map(function (attendee) {
-        icsFormat += `ATTENDEE;${setContact(attendee)}\r\n`
+        icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
       })
     }
     if (alarms) {

--- a/src/utils/fold-line.js
+++ b/src/utils/fold-line.js
@@ -1,0 +1,12 @@
+
+export default function foldLine (line) {
+  const parts = []
+  let length = 75
+  while (line.length > length) {
+    parts.push(line.slice(0, length))
+    line = line.slice(length)
+    length = 74
+  }
+  parts.push(line)
+  return parts.join('\r\n\t')
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,6 +7,7 @@ import setOrganizer from './set-organizer'
 import setAlarm from './set-alarm'
 import setDescription from './set-description'
 import formatDuration from './format-duration'
+import foldLine from './fold-line'
 
 export {
   setDate,
@@ -17,5 +18,6 @@ export {
   setOrganizer,
   setAlarm,
   formatDuration,
-  setDescription
+  setDescription,
+  foldLine
 }

--- a/src/utils/set-alarm.js
+++ b/src/utils/set-alarm.js
@@ -1,4 +1,5 @@
 import setDate from './set-date'
+import foldLine from './fold-line'
 import _ from 'lodash'
 
 function setDuration ({
@@ -47,13 +48,13 @@ export default function setAlarm(attributes = {}) {
   } = attributes
 
   let formattedString = 'BEGIN:VALARM\r\n'
-  formattedString += `ACTION:${setAction(action)}\r\n`
-  formattedString += repeat ? `REPEAT:${repeat}\r\n` : ''
-  formattedString += description ? `DESCRIPTION:${description}\r\n` : ''
-  formattedString += duration ? `DURATION:${setDuration(duration)}\r\n` : ''
-  formattedString += attach ? `ATTACH;FMTTYPE=audio/basic:${attach}\r\n` : ''
+  formattedString += foldLine(`ACTION:${setAction(action)}`) + '\r\n'
+  formattedString += repeat ? (foldLine(`REPEAT:${repeat}`) + '\r\n') : ''
+  formattedString += description ? (foldLine(`DESCRIPTION:${description}`) + '\r\n') : ''
+  formattedString += duration ? (foldLine(`DURATION:${setDuration(duration)}`) + '\r\n') : ''
+  formattedString += attach ? (foldLine(`ATTACH;FMTTYPE=audio/basic:${attach}`) + '\r\n') : ''
   formattedString += trigger ? setTrigger(trigger) : ''
-  formattedString += summary ? `SUMMARY:${summary}\r\n` : ''
+  formattedString += summary ? (foldLine(`SUMMARY:${summary}`) + '\r\n') : ''
   formattedString += 'END:VALARM\r\n'
 
   return formattedString

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -39,6 +39,11 @@ describe('pipeline.formatEvent', () => {
     const formattedEvent = formatEvent(event)
     expect(formattedEvent).to.contain('DESCRIPTION:bar baz')
   })
+  it('folds a long description', () => {
+    const event = buildEvent({ description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.' })
+    const formattedEvent = formatEvent(event)
+    expect(formattedEvent).to.contain('DESCRIPTION:Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do\r\n\t eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad mi\r\n\tnim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex e\r\n\ta commodo consequat. Duis aute irure dolor in reprehenderit in voluptate v\r\n\telit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat \r\n\tcupidatat non proident, sunt in culpa qui officia deserunt mollit anim id \r\n\test laborum.')
+  })
   it('writes a url', () => {
     const event = buildEvent({ url: 'http://www.example.com/' })
     const formattedEvent = formatEvent(event)
@@ -97,5 +102,24 @@ describe('pipeline.formatEvent', () => {
     expect(formattedEvent).to.contain('ACTION:AUDIO')
     expect(formattedEvent).to.contain('ATTACH;FMTTYPE=audio/basic:ftp://example.com/pub/sounds/bell-01.aud')
     expect(formattedEvent).to.contain('END:VALARM')
+  })
+  it('never writes lines longer than 75 characters, excluding CRLF', () => {
+    const formattedEvent = formatEvent({
+      productId: '*'.repeat(1000),
+      title: '*'.repeat(1000),
+      description: '*'.repeat(1000),
+      url: '*'.repeat(1000),
+      geo: '*'.repeat(1000),
+      location: '*'.repeat(1000),
+      status: '*'.repeat(1000),
+      categories: '*'.repeat(1000),
+      organizer: '*'.repeat(1000),
+      attendees: [
+        {name: '*'.repeat(1000), email: '*'.repeat(1000)},
+        {name: '*'.repeat(1000), email: '*'.repeat(1000), rsvp: true}
+      ]
+    })
+    const max = Math.max(...formattedEvent.split('\r\n').map(line => line.length))
+    expect(max).to.be.at.most(75)
   })
 })


### PR DESCRIPTION
This PR introduces a utility function called `foldLine` to address lines longer than 75 characters. See https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html.

`foldLine` is applied to formatting for all fields that I thought might overflow. The list of fields that get this treatment probably need review.

RFC2425 §5.8.2 states that parsers MUST unfold lines correctly:
```
  ; When parsing a content line, folded lines MUST first
  ; be unfolded according to the unfolding procedure
  ; described above.  When generating a content line, lines
  ; longer than 75 octets SHOULD be folded according to
  ; the folding procedure described above.
```

Potential risk: I don't know the state of most parsers out there, or if folding, say, a URL might confuse them.

I recall having trouble (I think on Outlook?) for .ics files that were not folded. And [it looks like google calendar](https://www.drupal.org/project/date/issues/1176548) may have this problem as well.
