### PR TITLE
Fix #74

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,10 @@ export function createEvents (events, cb) {
     return { error: Error('one argument is required'), value: null }
   }
 
+  if (events.length === 1) {
+    return createEvent(events[0], cb)
+  }
+
   const { error, value } = events.map(assignUniqueId)
     .map(applyInitialFormatting)
     .map(reformatEventsByPosition)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,6 +37,13 @@ describe('ics', () => {
       const events = createEvents()
       expect(events.error).to.exist
     })
+    it('writes begin and end calendar tags', () => {
+      const { error, value } = createEvents([validAttributes])
+      console.log(error, value)
+      expect(error).to.be.null
+      expect(value).to.contain('BEGIN:VCALENDAR')
+      expect(value).to.contain('END:VCALENDAR')
+    })
 
     describe('when no callback is provided', () => {
       it('returns an iCal string and a null error when passed valid events', () => {


### PR DESCRIPTION
Short-circuits `createEvents` in case only one event is passed in. Also adds a unit test for the reported issue.