### PR TITLE
Allow DIR attribute into organizer and attendees

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -21,7 +21,8 @@ const durationSchema = Joi.object().keys({
 const contactSchema = Joi.object().keys({
   name: Joi.string(),
   email: Joi.string().email(),
-  rsvp: Joi.boolean()
+  rsvp: Joi.boolean(),
+  dir: Joi.string().uri()
 })
 
 const organizerSchema = Joi.object().keys({

--- a/src/utils/set-contact.js
+++ b/src/utils/set-contact.js
@@ -1,6 +1,7 @@
-export default function setContact({ name, email, rsvp }) {
+export default function setContact({ name, email, rsvp, dir }) {
   let formattedAttendee = ''
   formattedAttendee += rsvp ? 'RSVP=TRUE;' : 'RSVP=FALSE;'
+  formattedAttendee += dir ? `DIR=${dir};` : ''
   formattedAttendee += 'CN='
   formattedAttendee += name || 'Unnamed attendee'
   formattedAttendee += email ? `:mailto:${email}` : ''

--- a/src/utils/set-organizer.js
+++ b/src/utils/set-organizer.js
@@ -1,5 +1,6 @@
-export default function setOrganizer({ name, email }) {
+export default function setOrganizer({ name, email, dir }) {
   let formattedOrganizer = ''
+  formattedOrganizer += dir ? `DIR=${dir};` : ''
   formattedOrganizer += 'CN='
   formattedOrganizer += name || 'Organizer'
   formattedOrganizer += email ? `:mailto:${email}` : ''

--- a/test/utils/set-contact.spec.js
+++ b/test/utils/set-contact.spec.js
@@ -11,13 +11,14 @@ describe('utils.setContact', () => {
     const contact2 = {
       name: 'Adam Gibbons',
       email: 'adam@example.com',
-      rsvp: true
+      rsvp: true,
+      dir: 'https://example.com/contacts/adam'
     }
 
     expect(setContact(contact1))
     .to.equal('RSVP=FALSE;CN=Adam Gibbons:mailto:adam@example.com')
 
     expect(setContact(contact2))
-    .to.equal('RSVP=TRUE;CN=Adam Gibbons:mailto:adam@example.com')
+    .to.equal('RSVP=TRUE;DIR=https://example.com/contacts/adam;CN=Adam Gibbons:mailto:adam@example.com')
   })
 })


### PR DESCRIPTION
This PR adds [DIR](https://www.kanzaki.com/docs/ical/dir.html) attribute into `organizer` and `attendees` (related to #86).