### PR TITLE
Create unique UID's for each time createEvent is called

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import {
 
 function assignUniqueId(event) {
   event.uid = event.uid || uuid()
+  return event
+}
+function validateAndBuildEvent(event) {
   return validateEvent(buildEvent(event))
 }
 
@@ -53,9 +56,11 @@ function catenateEvents(accumulator, { error, value }, idx) {
 export function createEvent (attributes, cb) {
   if (!attributes) { Error('Attributes argument is required') }
 
+  assignUniqueId(attributes)
+
   if (!cb) {
     // No callback, so return error or value in an object
-    const { error, value } = validateEvent(buildEvent(attributes))
+    const { error, value } = validateAndBuildEvent(attributes)
 
     if (error) return { error, value }
 
@@ -71,8 +76,8 @@ export function createEvent (attributes, cb) {
   }
 
   // Return a node-style callback
-  const { error, value } = validateEvent(buildEvent(attributes))
-  
+  const { error, value } = validateAndBuildEvent(attributes)
+
   if (error) return cb(error)
 
   return cb(null, formatEvent(value))
@@ -88,6 +93,7 @@ export function createEvents (events, cb) {
   }
 
   const { error, value } = events.map(assignUniqueId)
+    .map(validateAndBuildEvent)
     .map(applyInitialFormatting)
     .map(reformatEventsByPosition)
     .reduce(catenateEvents, { error: null, value: null })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -30,6 +30,16 @@ describe('ics', () => {
         expect(success).to.contain('DTSTART:200010')
       })
     })
+    it('returns unique uid\'s for multiple calls', () => {
+      const event1 = createEvent(validAttributes);
+      const event2 = createEvent(validAttributes2);
+
+      var uidRegex = /UID:(.*)/;
+
+      const event1Id = uidRegex.exec(event1.value)[1];
+      const event2Id = uidRegex.exec(event2.value)[1];
+      expect(event1Id).to.not.equal(event2Id);
+    });
   })
 
   describe('.createEvents', () => {


### PR DESCRIPTION
I was asynchronously creating multiple instances of an ical using `createEvent` and when I tried to load them up as a test (one at a time) - each one created would make the first one flash as though it was already existing (even though each new event was unique) and not actually add that new event.

Digging in - I discovered that they all had the same UID.

Any thoughts on taking this PR to avoid this issue?

-- I ended up using `createEvents` in the end - but hopefully this PR helps the next one who tries what I did...