### PR TITLE
Format seconds

### DIFF
--- a/src/utils/format-utc-date-as-utc.js
+++ b/src/utils/format-utc-date-as-utc.js
@@ -25,7 +25,7 @@ export default function formatUTCDateAsUTC(args = []) {
       hours,
       minutes,
       seconds
-    ]).format('YYYYMMDDTHHmm00') + 'Z'
+    ]).format('YYYYMMDDTHHmmss') + 'Z'
 
     return formattedDate
   }


### PR DESCRIPTION
Format seconds rather than hardcoding `00`

closes #135 