### PR TITLE
createEvents: return iCal string with 0 events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,22 @@ export function createEvents (events, cb) {
     return { error: Error('one argument is required'), value: null }
   }
 
+  if (events.length === 0) {
+    const {error, value: dummy} = createEvent({
+      start: [2000, 10, 5, 5, 0],
+      duration: { hours: 1 }
+    })
+    if (error) return {error, value: null}
+
+    return {
+      error: null,
+      value: (
+        dummy.slice(0, dummy.indexOf('BEGIN:VEVENT')) +
+        dummy.slice(dummy.indexOf('END:VEVENT') + 10 + 2)
+      )
+    }
+  }
+
   if (events.length === 1) {
     return createEvent(events[0], cb)
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -69,6 +69,12 @@ describe('ics', () => {
         expect(error).to.exist
         expect(value).not.to.exist
       })
+
+      it('returns an iCal string when passed 0 events', () => {
+        const { error, value } = createEvents([])
+        expect(error).to.be.null
+        expect(value).to.contain('BEGIN:VCALENDAR')
+      })
     })
 
     describe('when a callback is provided', () => {
@@ -84,6 +90,14 @@ describe('ics', () => {
         createEvents([validAttributes, validAttributes2, invalidAttributes], (error, success) => {
           expect(error).to.exist
           expect(success).not.to.exist
+          done()
+        })
+      })
+
+      it('returns an iCal string when passed 0 events', () => {
+        createEvents([], (error, value) => {
+          expect(error).to.be.null
+          expect(value).to.contain('BEGIN:VCALENDAR')
           done()
         })
       })


### PR DESCRIPTION
Right now, `createEvents` will return `{error: null, value: null}` with 0 events. This is impractical, because IMO it is a common use case to server a calendar feed with 0 events (e.g. no upcoming events, or all cancelled/removed).

This PR changes `createEvents` to return an empty (but valid) calendar feed in this case. Strictly speaking, this is a breaking change.