### PR TITLE
Remove dependency on lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3090,7 +3090,8 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "lodash": "^4.17.15",
     "uuid": "^3.3.3",
     "dayjs": "^1.8.33"
   },

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -10,7 +10,6 @@ import {
     formatDuration,
     foldLine
 } from '../utils'
-import isEqual from 'lodash/isEqual'
 
 export default function formatEvent(attributes = {}) {
   const {
@@ -61,9 +60,9 @@ export default function formatEvent(attributes = {}) {
   icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`
 
   // End is not required for all day events on single days (like anniversaries)
-  if (!(isEqual(start, end) && end && end.length == 3)) {
+  if (!end || end.length !== 3 || start.length !== end.length || start.some((val, i) => val !== end[i])) {
     if (end) {
-      icsFormat += `DTEND${end.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
+      icsFormat += `DTEND${end.length === 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
     }
   }
 

--- a/src/utils/set-alarm.js
+++ b/src/utils/set-alarm.js
@@ -1,6 +1,5 @@
 import formatDate from './format-date'
 import foldLine from './fold-line'
-import isArray from 'lodash/isArray'
 
 function setDuration ({
   weeks,
@@ -22,7 +21,7 @@ function setDuration ({
 
 function setTrigger (trigger) {
   let formattedString = ''
-  if(isArray(trigger)) {
+  if(Array.isArray(trigger)) {
     formattedString = `TRIGGER;VALUE=DATE-TIME:${formatDate(trigger)}\r\n`
   } else {
     let alert = trigger.before ? '-' : ''


### PR DESCRIPTION
`lodash` is included as a dependency for two very trivial purposes - it's unnecessary.

 - `_.isEqual` was used to check that `start` and `end` arrays were unequal. `start.length !== end.length || start.some((val, i) => val !== end[i])` has the same effect.
 - `_.isArray` is implemented by lodash with native `Array.isArray` wherever it is available anyway, which is [pretty much everywhere](https://caniuse.com/?search=Array.isArray). (This lib already uses `Object.assign`, which is [much newer](https://caniuse.com/?search=Object.assign))