### PR TITLE
Add created and lastModified to EventAttributes type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,8 @@ export type EventAttributes = {
   recurrenceRule?: string;
   sequence?: number;
   calName?: string;
+  created?: DateArray;
+  lastModified?: DateArray;
 } & ({ end: DateArray } | { duration: DurationObject });
 
 export type ReturnObject = { error?: Error; value?: string };


### PR DESCRIPTION
## Description

- `created` and `lastModified` are available to be set in the config but they are not accounted for in the `EventAttributes` type.

![image](https://user-images.githubusercontent.com/34139730/97251391-26703b00-17de-11eb-800a-7250c4dc1b2b.png)
