### PR TITLE
feature: allow to disable adding DTSTAMP while creating events

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The following properties are accepted:
 | created | Date-time representing event's creation date. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | lastModified | Date-time representing date when event was last modified. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | calName       |  Specifies the _calendar_ (not event) name. Used by Apple iCal and Microsoft Outlook; see [Open Specification](https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d) | `'Example Calendar'` |
+| datestamp     |  Specifies if `DTSTAMP` timestamp is added to the event |  |
 
 To create an **all-day** event, pass only three values (`year`, `month`, and `date`) to the `start` and `end` properties.
 The date of the `end` property should be the day *after* your all-day event.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The following properties are accepted:
 | created | Date-time representing event's creation date. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | lastModified | Date-time representing date when event was last modified. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | calName       |  Specifies the _calendar_ (not event) name. Used by Apple iCal and Microsoft Outlook; see [Open Specification](https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d) | `'Example Calendar'` |
-| datestamp     |  Specifies if `DTSTAMP` timestamp is added to the event |  |
+| datestamp     |  Specifies if `DTSTAMP` timestamp is added to the event. Optional, default value is `true` |  |
 
 To create an **all-day** event, pass only three values (`year`, `month`, and `date`) to the `start` and `end` properties.
 The date of the `end` property should be the day *after* your all-day event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ export type EventAttributes = {
   calName?: string;
   created?: DateArray;
   lastModified?: DateArray;
+  datestamp?: true | false;
 } & ({ end: DateArray } | { duration: DurationObject });
 
 export type ReturnObject = { error?: Error; value?: string };

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -1,14 +1,14 @@
 import {
-  setAlarm,
-  setContact,
-  setOrganizer,
-  formatDate,
-  setDescription,
-  setLocation,
-  setSummary,
-  setGeolocation,
-  formatDuration,
-  foldLine
+    setAlarm,
+    setContact,
+    setOrganizer,
+    formatDate,
+    setDescription,
+    setLocation,
+    setSummary,
+    setGeolocation,
+    formatDuration,
+    foldLine
 } from '../utils'
 
 export default function formatEvent(attributes = {}) {

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -12,88 +12,88 @@ import {
 } from '../utils'
 
 export default function formatEvent(attributes = {}) {
-const {
-  title,
-  productId,
-  method,
-  uid,
-  sequence,
-  timestamp,
-  start,
-  startType,
-  startInputType,
-  startOutputType,
-  duration,
-  end,
-  endInputType,
-  endOutputType,
-  description,
-  url,
-  geo,
-  location,
-  status,
-  categories,
-  organizer,
-  attendees,
-  alarms,
-  recurrenceRule,
-  busyStatus,
-  created,
-  lastModified,
-  calName,
-  datestamp
-} = attributes
+  const {
+    title,
+    productId,
+    method,
+    uid,
+    sequence,
+    timestamp,
+    start,
+    startType,
+    startInputType,
+    startOutputType,
+    duration,
+    end,
+    endInputType,
+    endOutputType,
+    description,
+    url,
+    geo,
+    location,
+    status,
+    categories,
+    organizer,
+    attendees,
+    alarms,
+    recurrenceRule,
+    busyStatus,
+    created,
+    lastModified,
+    calName,
+    datestamp
+  } = attributes
 
-let icsFormat = ''
-icsFormat += 'BEGIN:VCALENDAR\r\n'
-icsFormat += 'VERSION:2.0\r\n'
-icsFormat += 'CALSCALE:GREGORIAN\r\n'
-icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
-icsFormat += foldLine(`METHOD:${method}`) + '\r\n'
-icsFormat += calName ? (foldLine(`X-WR-CALNAME:${calName}`) + '\r\n') : ''
-icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
-icsFormat += 'BEGIN:VEVENT\r\n'
-icsFormat += `UID:${uid}\r\n`
-icsFormat +=  foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
+  let icsFormat = ''
+  icsFormat += 'BEGIN:VCALENDAR\r\n'
+  icsFormat += 'VERSION:2.0\r\n'
+  icsFormat += 'CALSCALE:GREGORIAN\r\n'
+  icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
+  icsFormat += foldLine(`METHOD:${method}`) + '\r\n'
+  icsFormat += calName ? (foldLine(`X-WR-CALNAME:${calName}`) + '\r\n') : ''
+  icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
+  icsFormat += 'BEGIN:VEVENT\r\n'
+  icsFormat += `UID:${uid}\r\n`
+  icsFormat +=  foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
 
-// All day events like anniversaries must be specified as VALUE type DATE
-icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`
+  // All day events like anniversaries must be specified as VALUE type DATE
+  icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`
 
-// End is not required for all day events on single days (like anniversaries)
-if (!end || end.length !== 3 || start.length !== end.length || start.some((val, i) => val !== end[i])) {
-  if (end) {
-    icsFormat += `DTEND${end.length === 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
+  // End is not required for all day events on single days (like anniversaries)
+  if (!end || end.length !== 3 || start.length !== end.length || start.some((val, i) => val !== end[i])) {
+    if (end) {
+      icsFormat += `DTEND${end.length === 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
+    }
   }
-}
 
-icsFormat += datestamp ? `DTSTAMP:${timestamp}\r\n` : ''
-icsFormat += sequence ? (`SEQUENCE:${sequence}\r\n`) : ''
-icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
-icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
-icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''
-icsFormat += location ? (foldLine(`LOCATION:${setLocation(location)}`) + '\r\n') : ''
-icsFormat += status ? (foldLine(`STATUS:${status}`) + '\r\n') : ''
-icsFormat += categories ? (foldLine(`CATEGORIES:${categories}`) + '\r\n') : ''
-icsFormat += organizer ? (foldLine(`ORGANIZER;${setOrganizer(organizer)}`) + '\r\n') : ''
-icsFormat += busyStatus ? (foldLine(`X-MICROSOFT-CDO-BUSYSTATUS:${busyStatus}`) + '\r\n') : ''
-icsFormat += created ? ('CREATED:' + formatDate(created) + '\r\n') : ''
-icsFormat += lastModified ? ('LAST-MODIFIED:' + formatDate(lastModified) + '\r\n') : ''
-if (attendees) {
-  attendees.map(function (attendee) {
-    icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
-  })
-}
+  icsFormat += datestamp ? `DTSTAMP:${timestamp}\r\n` : ''
+  icsFormat += sequence ? (`SEQUENCE:${sequence}\r\n`) : ''
+  icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
+  icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
+  icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''
+  icsFormat += location ? (foldLine(`LOCATION:${setLocation(location)}`) + '\r\n') : ''
+  icsFormat += status ? (foldLine(`STATUS:${status}`) + '\r\n') : ''
+  icsFormat += categories ? (foldLine(`CATEGORIES:${categories}`) + '\r\n') : ''
+  icsFormat += organizer ? (foldLine(`ORGANIZER;${setOrganizer(organizer)}`) + '\r\n') : ''
+  icsFormat += busyStatus ? (foldLine(`X-MICROSOFT-CDO-BUSYSTATUS:${busyStatus}`) + '\r\n') : ''
+  icsFormat += created ? ('CREATED:' + formatDate(created) + '\r\n') : ''
+  icsFormat += lastModified ? ('LAST-MODIFIED:' + formatDate(lastModified) + '\r\n') : ''
+  if (attendees) {
+    attendees.map(function (attendee) {
+      icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
+    })
+  }
 
-if (alarms) {
-  alarms.map(function (alarm) {
-    icsFormat += setAlarm(alarm)
-  })
-}
+  if (alarms) {
+    alarms.map(function (alarm) {
+      icsFormat += setAlarm(alarm)
+    })
+  }
 
-icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
-icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
-icsFormat += `END:VEVENT\r\n`
-icsFormat += `END:VCALENDAR\r\n`
+  icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
+  icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
+  icsFormat += `END:VEVENT\r\n`
+  icsFormat += `END:VCALENDAR\r\n`
 
-return icsFormat
+  return icsFormat
 }

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -1,98 +1,99 @@
 import {
-    setAlarm,
-    setContact,
-    setOrganizer,
-    formatDate,
-    setDescription,
-    setLocation,
-    setSummary,
-    setGeolocation,
-    formatDuration,
-    foldLine
+  setAlarm,
+  setContact,
+  setOrganizer,
+  formatDate,
+  setDescription,
+  setLocation,
+  setSummary,
+  setGeolocation,
+  formatDuration,
+  foldLine
 } from '../utils'
 
 export default function formatEvent(attributes = {}) {
-  const {
-    title,
-    productId,
-    method,
-    uid,
-    sequence,
-    timestamp,
-    start,
-    startType,
-    startInputType,
-    startOutputType,
-    duration,
-    end,
-    endInputType,
-    endOutputType,
-    description,
-    url,
-    geo,
-    location,
-    status,
-    categories,
-    organizer,
-    attendees,
-    alarms,
-    recurrenceRule,
-    busyStatus,
-    created,
-    lastModified,
-    calName
-  } = attributes
+const {
+  title,
+  productId,
+  method,
+  uid,
+  sequence,
+  timestamp,
+  start,
+  startType,
+  startInputType,
+  startOutputType,
+  duration,
+  end,
+  endInputType,
+  endOutputType,
+  description,
+  url,
+  geo,
+  location,
+  status,
+  categories,
+  organizer,
+  attendees,
+  alarms,
+  recurrenceRule,
+  busyStatus,
+  created,
+  lastModified,
+  calName,
+  datestamp
+} = attributes
 
-  let icsFormat = ''
-  icsFormat += 'BEGIN:VCALENDAR\r\n'
-  icsFormat += 'VERSION:2.0\r\n'
-  icsFormat += 'CALSCALE:GREGORIAN\r\n'
-  icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
-  icsFormat += foldLine(`METHOD:${method}`) + '\r\n'
-  icsFormat += calName ? (foldLine(`X-WR-CALNAME:${calName}`) + '\r\n') : ''
-  icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
-  icsFormat += 'BEGIN:VEVENT\r\n'
-  icsFormat += `UID:${uid}\r\n`
-  icsFormat +=  foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
-  icsFormat += `DTSTAMP:${timestamp}\r\n`
+let icsFormat = ''
+icsFormat += 'BEGIN:VCALENDAR\r\n'
+icsFormat += 'VERSION:2.0\r\n'
+icsFormat += 'CALSCALE:GREGORIAN\r\n'
+icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
+icsFormat += foldLine(`METHOD:${method}`) + '\r\n'
+icsFormat += calName ? (foldLine(`X-WR-CALNAME:${calName}`) + '\r\n') : ''
+icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
+icsFormat += 'BEGIN:VEVENT\r\n'
+icsFormat += `UID:${uid}\r\n`
+icsFormat +=  foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
 
-  // All day events like anniversaries must be specified as VALUE type DATE
-  icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`
+// All day events like anniversaries must be specified as VALUE type DATE
+icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`
 
-  // End is not required for all day events on single days (like anniversaries)
-  if (!end || end.length !== 3 || start.length !== end.length || start.some((val, i) => val !== end[i])) {
-    if (end) {
-      icsFormat += `DTEND${end.length === 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
-    }
+// End is not required for all day events on single days (like anniversaries)
+if (!end || end.length !== 3 || start.length !== end.length || start.some((val, i) => val !== end[i])) {
+  if (end) {
+    icsFormat += `DTEND${end.length === 3 ? ";VALUE=DATE" : ""}:${formatDate(end, endOutputType || startOutputType || startType, endInputType || startInputType)}\r\n`;
   }
+}
 
-  icsFormat += sequence ? (`SEQUENCE:${sequence}\r\n`) : ''
-  icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
-  icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
-  icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''
-  icsFormat += location ? (foldLine(`LOCATION:${setLocation(location)}`) + '\r\n') : ''
-  icsFormat += status ? (foldLine(`STATUS:${status}`) + '\r\n') : ''
-  icsFormat += categories ? (foldLine(`CATEGORIES:${categories}`) + '\r\n') : ''
-  icsFormat += organizer ? (foldLine(`ORGANIZER;${setOrganizer(organizer)}`) + '\r\n') : ''
-  icsFormat += busyStatus ? (foldLine(`X-MICROSOFT-CDO-BUSYSTATUS:${busyStatus}`) + '\r\n') : ''
-  icsFormat += created ? ('CREATED:' + formatDate(created) + '\r\n') : ''
-  icsFormat += lastModified ? ('LAST-MODIFIED:' + formatDate(lastModified) + '\r\n') : ''
-  if (attendees) {
-    attendees.map(function (attendee) {
-      icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
-    })
-  }
+icsFormat += datestamp ? `DTSTAMP:${timestamp}\r\n` : ''
+icsFormat += sequence ? (`SEQUENCE:${sequence}\r\n`) : ''
+icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
+icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
+icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''
+icsFormat += location ? (foldLine(`LOCATION:${setLocation(location)}`) + '\r\n') : ''
+icsFormat += status ? (foldLine(`STATUS:${status}`) + '\r\n') : ''
+icsFormat += categories ? (foldLine(`CATEGORIES:${categories}`) + '\r\n') : ''
+icsFormat += organizer ? (foldLine(`ORGANIZER;${setOrganizer(organizer)}`) + '\r\n') : ''
+icsFormat += busyStatus ? (foldLine(`X-MICROSOFT-CDO-BUSYSTATUS:${busyStatus}`) + '\r\n') : ''
+icsFormat += created ? ('CREATED:' + formatDate(created) + '\r\n') : ''
+icsFormat += lastModified ? ('LAST-MODIFIED:' + formatDate(lastModified) + '\r\n') : ''
+if (attendees) {
+  attendees.map(function (attendee) {
+    icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
+  })
+}
 
-  if (alarms) {
-    alarms.map(function (alarm) {
-      icsFormat += setAlarm(alarm)
-    })
-  }
+if (alarms) {
+  alarms.map(function (alarm) {
+    icsFormat += setAlarm(alarm)
+  })
+}
 
-  icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
-  icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
-  icsFormat += `END:VEVENT\r\n`
-  icsFormat += `END:VCALENDAR\r\n`
+icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
+icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
+icsFormat += `END:VEVENT\r\n`
+icsFormat += `END:VCALENDAR\r\n`
 
-  return icsFormat
+return icsFormat
 }

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -75,7 +75,8 @@ const schema = Joi.object().keys({
   busyStatus: Joi.string().regex(/TENTATIVE|FREE|BUSY|OOF/),
   created: dateTimeSchema,
   lastModified: dateTimeSchema,
-  calName: Joi.string()
+  calName: Joi.string(),
+  datestamp: Joi.boolean()
 }).xor('end', 'duration')
 
 export default function validateEvent(candidate) {

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -17,7 +17,6 @@ describe('pipeline.formatEvent', () => {
     expect(formattedEvent).to.contain('UID:')
     expect(formattedEvent).to.not.contain('SEQUENCE:')
     expect(formattedEvent).to.contain('DTSTART:')
-    expect(formattedEvent).to.contain('DTSTAMP:20')
     expect(formattedEvent).to.contain('END:VEVENT')
     expect(formattedEvent).to.contain('END:VCALENDAR')
   })


### PR DESCRIPTION
Current situation:
createEvents function creates DTSTAMP for every event and doesn't provide a way to disable this

Why is this a problem:
Would be nice to not have it there and use for example a file hash for versioning, useful in cases where software pulls new file and wants to know if it changed based on file hash

Desired situation:
option to disable adding DTSTAMP on createEvents function