### PR TITLE
feat: allow to disable adding DTSTAMP on events

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The following properties are accepted:
 | created | Date-time representing event's creation date. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | lastModified | Date-time representing date when event was last modified. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | calName       |  Specifies the _calendar_ (not event) name. Used by Apple iCal and Microsoft Outlook; see [Open Specification](https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d) | `'Example Calendar'` |
+| disableDatestamp     |  Specifies if `DTSTAMP` timestamp is not added to the event. |  |
 
 To create an **all-day** event, pass only three values (`year`, `month`, and `date`) to the `start` and `end` properties.
 The date of the `end` property should be the day *after* your all-day event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,6 +87,7 @@ export type EventAttributes = {
   calName?: string;
   created?: DateArray;
   lastModified?: DateArray;
+  disableTimestamp?: boolean;
 } & ({ end: DateArray } | { duration: DurationObject });
 
 export type ReturnObject = { error?: Error; value?: string };

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -40,7 +40,8 @@ export default function formatEvent(attributes = {}) {
     busyStatus,
     created,
     lastModified,
-    calName
+    calName,
+    disableDatestamp
   } = attributes
 
   let icsFormat = ''
@@ -53,8 +54,8 @@ export default function formatEvent(attributes = {}) {
   icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
   icsFormat += 'BEGIN:VEVENT\r\n'
   icsFormat += `UID:${uid}\r\n`
-  icsFormat +=  foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
-  icsFormat += `DTSTAMP:${timestamp}\r\n`
+  icsFormat += foldLine(`SUMMARY:${title ? setSummary(title) : title}`) + '\r\n'
+  icsFormat += !disableDatestamp ? `DTSTAMP:${timestamp}\r\n` : ''
 
   // All day events like anniversaries must be specified as VALUE type DATE
   icsFormat += `DTSTART${start && start.length == 3 ? ";VALUE=DATE" : ""}:${formatDate(start, startOutputType || startType, startInputType)}\r\n`

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -75,7 +75,8 @@ const schema = Joi.object().keys({
   busyStatus: Joi.string().regex(/TENTATIVE|FREE|BUSY|OOF/),
   created: dateTimeSchema,
   lastModified: dateTimeSchema,
-  calName: Joi.string()
+  calName: Joi.string(),
+  disableDatestamp: Joi.boolean()
 }).xor('end', 'duration')
 
 export default function validateEvent(candidate) {

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -236,4 +236,9 @@ describe('pipeline.formatEvent', () => {
 
     expect(formattedEvent).to.contain('RRULE:FREQ=DAILY')
   })
+  it('writes event without DTSTAMP timestamp', () => {
+    const event = buildEvent({ disableDatestamp: true })
+    const formattedEvent = formatEvent(event)
+    expect(formattedEvent).to.not.contain('DTSTAMP:20')
+  })
 })


### PR DESCRIPTION
Current situation:
createEvents function creates DTSTAMP for every event and doesn't provide a way to disable this

Why is this a problem:
Would be nice to not have it there and use for example a file hash for versioning, useful in cases where software pulls new file and wants to know if it changed based on file hash

Desired situation:
option to disable adding DTSTAMP on createEvents function