### PR TITLE
Support sequence as zero

### DIFF
--- a/src/pipeline/build.js
+++ b/src/pipeline/build.js
@@ -1,5 +1,4 @@
 import pickBy from "lodash/pickBy";
-import identity from "lodash/identity";
 import defaultAttributes from "../defaults";
 
 export default function buildEvent(attributes = {}) {
@@ -31,8 +30,8 @@ export default function buildEvent(attributes = {}) {
   // fill in default values where necessary
   const output = Object.assign({}, defaultAttributes, attributes);
 
-  // remove falsey values
-  const cleanOutput = pickBy(output, identity);
+  // remove undefined values
+  const cleanOutput = pickBy(output, value => value !== undefined);
 
   return cleanOutput;
 }

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -66,7 +66,7 @@ export default function formatEvent(attributes = {}) {
     }
   }
 
-  icsFormat += sequence ? (`SEQUENCE:${sequence}\r\n`) : ''
+  icsFormat += typeof sequence === 'number' ? (`SEQUENCE:${sequence}\r\n`) : ''
   icsFormat += description ? (foldLine(`DESCRIPTION:${setDescription(description)}`) + '\r\n') : ''
   icsFormat += url ? (foldLine(`URL:${url}`) + '\r\n') : ''
   icsFormat += geo ? (foldLine(`GEO:${setGeolocation(geo)}`) + '\r\n') : ''

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -109,6 +109,11 @@ describe('pipeline.formatEvent', () => {
     const formattedEvent = formatEvent(event)
     expect(formattedEvent).to.contain('SEQUENCE:8')
   })
+  it("supports sequence as 0", () => {
+    const event = buildEvent({ sequence: 0 })
+    const formattedEvent = formatEvent(event)
+    expect(formattedEvent).to.contain("SEQUENCE:0")
+  })
   it('writes a description', () => {
     const event = buildEvent({ description: 'bar baz' })
     const formattedEvent = formatEvent(event)


### PR DESCRIPTION
This fixes a bug, where one cannot set the `sequence` attribute to zero. 

I had to remove the options filter that removes falsy values to get the zero value through. I believe that to be in line with user expectations (better errors than "silent" bugs) but if you'd rather I leave that be and only allow the zero to pass through for the `sequence` option, I can make that change.