### PR TITLE
fix error object

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -98,6 +98,6 @@ export default function validateEvent (candidate) {
     const value = schema.validateSync(candidate, {abortEarly: false, strict: true})
     return {error: null, value}
   } catch (error) {
-    return {error, value: undefined}
+    return {error: Object.assign({}, error), value: undefined}
   }
 }


### PR DESCRIPTION
The yup error object is a javascript Error which in turn makes logging
it a bit limiting, the stack trace gets dumped and the useful error
information is hidden.  It's still there, but it's presence isn't
obvious to the user, and this in turn limits its usability.

By cloning the fields over to a new object the same data remains but the
logging is improved and the behavior become more in line with that of
the joi version.