### PR TITLE
Add `description` field to `alarms` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ let end = moment().add({'hours':2, "minutes":30}).format("YYYY-M-D-H-m").split("
 
 alarms.push({
   action: 'audio',
+  description: 'Reminder',
   trigger: {hours:2,minutes:30,before:true},
   repeat: 2,
   attachType:'VALUE=URI',
@@ -225,7 +226,7 @@ The following properties are accepted:
 | organizer     | Person organizing the event | `{ name: 'Adam Gibbons', email: 'adam@example.com', dir: 'https://linkedin.com/in/adamgibbons' }`
 | attendees     | Persons invited to the event | `[{ name: 'Mo', email: 'mo@foo.com', rsvp: true }, { name: 'Bo', email: 'bo@bar.biz', dir: 'https://twitter.com/bo1234', partstat: 'ACCEPTED', role: 'REQ-PARTICIPANT' }]`
 | categories    | Categories associated with the event | `['hacknight', 'stout month']`
-| alarms        | Alerts that can be set to trigger before, during, or after the event. The following `attach` properties work on Mac OS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sousumi, Submarine, Tink | `{ action: 'display', trigger: [2000, 1, 4, 18, 30] }` OR `{ action: 'display', trigger: { hours: 2, minutes: 30, before: true }` OR `{ action: 'display', trigger: { hours: 2, minutes: 30, before: false }` OR `{ action: 'audio', trigger: { hours: 2, minutes: 30, before: true }, repeat: 2, attachType: 'VALUE=URI', attach: 'Glass' }`
+| alarms        | Alerts that can be set to trigger before, during, or after the event. The following `attach` properties work on Mac OS: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, Ping, Pop, Purr, Sousumi, Submarine, Tink | `{ action: 'display', description: 'Reminder', trigger: [2000, 1, 4, 18, 30] }` OR `{ action: 'display', description: 'Reminder', trigger: { hours: 2, minutes: 30, before: true } }` OR `{ action: 'display', description: 'Reminder', trigger: { hours: 2, minutes: 30, before: false }` OR `{ action: 'audio', description: 'Reminder', trigger: { hours: 2, minutes: 30, before: true }, repeat: 2, attachType: 'VALUE=URI', attach: 'Glass' }`
 | productId     | Product which created ics, `PRODID` field | `'adamgibbons/ics'`
 | uid           | Universal unique id for event, produced by default with `uuid/v1`.  **Warning:** This value must be **globally unique**.  It is recommended that it follow the [RFC 822 addr-spec](https://www.w3.org/Protocols/rfc822/) (i.e. `localpart@domain`).  Including the `@domain` half is a good way to ensure uniqueness. | `'28021620-be61-11e7-be87-5f3ab42f0785'`
 | method        | This property defines the iCalendar object method associated with the calendar object. When used in a MIME message entity, the value of this property MUST be the same as the Content-Type "method" parameter value.  If either the "METHOD" property or the Content-Type "method" parameter is specified, then the other MUST also be specified. | `PUBLISH`


### PR DESCRIPTION
In trying to diagnose an issue with why our ICS files were not being
validated correctly on iCalendar Validator due to a missing
'DESCRIPTION' within 'VALARM', I came across the ticket
from YM-KA stating that you could add the description field to the
alarms object without issue. I ran across in an iCalendar spec that the
description is one of three required fields for it to be valid as well,
so I thought that the README and it's examples regarding alarms should
reflect that, as there is currently no documentation of the description
field at all.  This would have saved me some time and hopefully will save
others the same fruustration.

This PR adds a `description` field to all instances of the `alarms`
array and the objects contained within.