### PR TITLE
Support for html content

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The following properties are accepted:
 | created | Date-time representing event's creation date. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | lastModified | Date-time representing date when event was last modified. Provide a date-time in UTC | [2000, 1, 5, 10, 0] (January 5, 2000 GMT +00:00)
 | calName       |  Specifies the _calendar_ (not event) name. Used by Apple iCal and Microsoft Outlook; see [Open Specification](https://docs.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d) | `'Example Calendar'` |
+| htmlContent       | Used to include HTML markup in an event's description. Standard DESCRIPTION tag should contain non-HTML version. | `<!DOCTYPE html><html><body><p>This is<br>test<br>html code.</p></body></html>` |
 
 To create an **all-day** event, pass only three values (`year`, `month`, and `date`) to the `start` and `end` properties.
 The date of the `end` property should be the day *after* your all-day event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ export type EventAttributes = {
   calName?: string;
   created?: DateArray;
   lastModified?: DateArray;
-  htmlContent: string;
+  htmlContent?: string;
 } & ({ end: DateArray } | { duration: DurationObject });
 
 export type ReturnObject = { error?: Error; value?: string };

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ export type EventAttributes = {
   calName?: string;
   created?: DateArray;
   lastModified?: DateArray;
+  htmlContent: string;
 } & ({ end: DateArray } | { duration: DurationObject });
 
 export type ReturnObject = { error?: Error; value?: string };

--- a/src/pipeline/build.js
+++ b/src/pipeline/build.js
@@ -23,7 +23,8 @@ export default function buildEvent(attributes = {}) {
     recurrenceRule,
     created,
     lastModified,
-    calName
+    calName,
+    htmlContent
   } = attributes;
 
   // fill in default values where necessary

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -40,7 +40,8 @@ export default function formatEvent(attributes = {}) {
     busyStatus,
     created,
     lastModified,
-    calName
+    calName,
+    htmlContent
   } = attributes
 
   let icsFormat = ''
@@ -77,6 +78,7 @@ export default function formatEvent(attributes = {}) {
   icsFormat += busyStatus ? (foldLine(`X-MICROSOFT-CDO-BUSYSTATUS:${busyStatus}`) + '\r\n') : ''
   icsFormat += created ? ('CREATED:' + formatDate(created) + '\r\n') : ''
   icsFormat += lastModified ? ('LAST-MODIFIED:' + formatDate(lastModified) + '\r\n') : ''
+  icsFormat += htmlContent ? (foldLine(`X-ALT-DESC;FMTTYPE=text/html:${htmlContent}`) + '\r\n') : ''
   if (attendees) {
     attendees.map(function (attendee) {
       icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -85,7 +85,8 @@ const schema = yup.object().shape({
   busyStatus: yup.string().matches(/TENTATIVE|FREE|BUSY|OOF/i),
   created: dateTimeSchema,
   lastModified: dateTimeSchema,
-  calName: yup.string()
+  calName: yup.string(),
+  htmlContent: yup.string()
 }).test('xor', `object should have end or duration`, val => {
   const hasEnd = !!val.end
   const hasDuration = !!val.duration

--- a/test/pipeline/build.spec.js
+++ b/test/pipeline/build.spec.js
@@ -82,6 +82,12 @@ describe('pipeline.build properties', () => {
       expect(event.calName).to.equal('John\'s Calendar')
     })
   })
+  describe('htmlContent', () => {
+    it('sets a html content', () => {
+      const event = buildEvent({ htmlContent: '<!DOCTYPE html><html><body><p>This is<br>test<br>html code.</p></body></html>' })
+      expect(event.htmlContent).to.equal('<!DOCTYPE html><html><body><p>This is<br>test<br>html code.</p></body></html>')
+    })
+  })
   describe('description', () => {
     it('removes a falsey value', () => {
       const event = buildEvent()

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -104,6 +104,11 @@ describe('pipeline.formatEvent', () => {
     const formattedEvent = formatEvent(event)
     expect(formattedEvent).to.contain('X-WR-CALNAME:John\'s Calendar')
   })
+  it('writes a html content and folds correctly', () => {
+    const event = buildEvent({ htmlContent: '<!DOCTYPE html><html><body><p>This is<br>test<br>html code.</p></body></html>' })
+    const formattedEvent = formatEvent(event)
+    expect(formattedEvent).to.contain(`X-ALT-DESC;FMTTYPE=text/html:<!DOCTYPE html><html><body><p>This is<br>test<\r\n\tbr>html code.</p></body></html>`)
+  })
   it('writes a sequence', () => {
     const event = buildEvent({ sequence: 8 })
     const formattedEvent = formatEvent(event)

--- a/test/schema/index.spec.js
+++ b/test/schema/index.spec.js
@@ -237,6 +237,15 @@ describe('.validateEvent', () => {
         start: [2018, 12, 1, 10, 30],
       }).value.calName).to.exist
     })
+
+    it('htmlContent', () => {
+      expect(validateEvent({
+        title: 'foo',
+        uid: 'foo',
+        htmlContent: '<!DOCTYPE html><html><body><p>This is<br>test<br>html code.</p></body></html>',
+        start: [2018, 12, 1, 10, 30],
+      }).value.htmlContent).to.exist
+    })
   })
 
   describe('may have one or more occurrences of', () => {


### PR DESCRIPTION
Using `X-ALT-DESC;FMTTYPE=text/html` attribute in ICS i added support for adding html content to the ICS file. It was discussed here: https://github.com/adamgibbons/ics/issues/119 