### PR TITLE
Remove 00 like default second value

### DIFF
--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -6,7 +6,7 @@ export default function formatDate(args = [], outputType = 'utc', inputType = 'l
     return `${year}${pad(month)}${pad(date)}`
   }
 
-  let outDate = new Date(new Date().setUTCSeconds(0, 0))
+  let outDate = new Date()
   if (Array.isArray(args) && args.length > 0 && args[0]) {
     const [year, month, date, hours = 0, minutes = 0, seconds = 0] = args
     if (inputType === 'local') {

--- a/test/utils/format-date.spec.js
+++ b/test/utils/format-date.spec.js
@@ -8,8 +8,8 @@ import { expect } from 'chai'
 
 describe('utils.formatDate', () => {
   it('defaults to local time input and UTC time output when no type passed', () => {
-    const now = dayjs(new Date(2017, 7-1, 16, 22, 30)).utc().format('YYYYMMDDTHHmm00')
-    expect(formatDate([2017, 7, 16, 22, 30])).to.equal(now+'Z')
+    const now = dayjs(new Date(2017, 7-1, 16, 22, 30, 35)).utc().format('YYYYMMDDTHHmmss')
+    expect(formatDate([2017, 7, 16, 22, 30, 35])).to.equal(now+'Z')
   })
   it('sets a local (i.e. floating) time when specified', () => {
     expect(formatDate([1998, 6, 18, 23, 0], 'local', 'local')).to.equal('19980618T230000')
@@ -18,7 +18,7 @@ describe('utils.formatDate', () => {
     expect(formatDate([2018, 2, 11])).to.equal('20180211')
   })
   it('defaults to NOW in UTC date-time when no args passed', () => {
-    const now = dayjs().utc().format('YYYYMMDDTHHmm00') + 'Z'
+    const now = dayjs().utc().format('YYYYMMDDTHHmmss') + 'Z'
     expect(formatDate(undefined, 'utc')).to.equal(now)
   })
   it('sets a UTC date-time when passed well-formed args', () => {
@@ -26,7 +26,7 @@ describe('utils.formatDate', () => {
     expect(formatDate([2017, 1, 31], 'utc','utc')).to.equal('20170131')
   })
   it('sets a local DATE-TIME value to NOW when passed nothing', () => {
-    const now = dayjs().format('YYYYMMDDTHHmm00')
+    const now = dayjs().format('YYYYMMDDTHHmmss')
     expect(formatDate(undefined, 'local', 'local')).to.equal(now)
   })
   it('sets a local DATE-TIME value when passed args', () => {


### PR DESCRIPTION
Remove the default second value because when you send an event request and an event cancel in the same second, Google Calendar omits event cancel.