### PR TITLE
Fix DIR format according to the RFC-5545

### DIFF
--- a/src/utils/set-organizer.js
+++ b/src/utils/set-organizer.js
@@ -1,6 +1,6 @@
 export default function setOrganizer({ name, email, dir }) {
   let formattedOrganizer = ''
-  formattedOrganizer += dir ? `DIR=${dir};` : ''
+  formattedOrganizer += dir ? `DIR="${dir}";` : ''
   formattedOrganizer += 'CN='
   formattedOrganizer += name || 'Organizer'
   formattedOrganizer += email ? `:mailto:${email}` : ''


### PR DESCRIPTION
# dirparam quote fix  
 
## Context
Hi there:)
I had a chance to work with your library and found that users with dir property aren't added as attendees to the native mac os calendar. So I've found that there is a missing quote. 

According to the [DIR RFC](https://datatracker.ietf.org/doc/html/rfc5545#section-3.2.6) the dir format should be next:
`dirparam   = "DIR" "=" DQUOTE uri DQUOTE`

For example: 
`ORGANIZER;DIR="ldap://example.com:6666":mailto:jimdo@example.com`

So I started to play with generated ics files and it was confirmed. When I add quotes I can see invitees, when remove I can't

## Fix 
- Wrap dir URI with quotes according to the specification.
## Possible regressions
- There are no possible regressions because this is done according to the rfc. Some clients can work without quotes but some of them can't, so this change will only improve the backward compatibility of this lib.