### PR TITLE
Alarm fix for Outlook (#210) and added missing types Alarm (#205)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,9 @@ export type classificationType = 'PUBLIC' | 'PRIVATE' | 'CONFIDENTIAL' | string;
 
 export type Alarm = {
   action?: ActionType;
+  description?: string;
+  summary?: string;
+  duration?: DurationObject;
   trigger?: DurationObject; // @todo DateArray | DurationObject;
   repeat?: number;
   attachType?: string;

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -86,15 +86,13 @@ export default function formatEvent(attributes = {}) {
       icsFormat += foldLine(`ATTENDEE;${setContact(attendee)}`) + '\r\n'
     })
   }
-
+  icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
+  icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
   if (alarms) {
     alarms.map(function (alarm) {
       icsFormat += setAlarm(alarm)
     })
   }
-
-  icsFormat += recurrenceRule ? `RRULE:${recurrenceRule}\r\n` : ''
-  icsFormat += duration ? `DURATION:${formatDuration(duration)}\r\n` : ''
   icsFormat += `END:VEVENT\r\n`
   icsFormat += `END:VCALENDAR\r\n`
 


### PR DESCRIPTION
I owe a lot to this module as it made my last big project at my day job possible. But I was hampered by two issues with simple solutions. I knew I had to fix them.

_By the way, this is my first public contribution via PR on GitHub. My first-time is long overdue. 😅_

First is #210 - where Outlook stops parsing after encountering `BEGIN:VALARM`. Thus, `RRULE:` and `DURATION:` will be ignored.

Here's a video demonstration of this issue. Simply re-ordering some lines fixes Outlook import.

https://user-images.githubusercontent.com/2433505/185986308-e79aa6c6-612e-40b7-9c41-dc7bbfb6505a.mp4

Second is #205 where the type definitions lack three properties for the `Alarm` type. I simply added these in, matching the behavior you find in `setAlarm()`.

I personally only needed `description`, but knew I could add the other two just to make it complete.
