### PR TITLE
Fix exports in package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-var ics = require('./dist');
-
-module.exports = ics;

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "3.0.1",
   "description": "iCal (ics) file generator",
   "exports": {
-    "require": "./index.js",
+    "types": "./index.d.ts",
     "default": "./dist/index.js"
   },
-  "main": "index.js",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "index.d.ts",
   "scripts": {
     "start": "mocha --require @babel/register --watch --recursive",


### PR DESCRIPTION
TypeScript 4.7 introduced the `node16` module resolution. This is more strict, and more correct than older module resolution options.

According to TypeScript, before this change it is possible to use `require('ics')`, but not `import 'ics'` from native ESM. This is because there is an explicit `require` export, that is accompanied by a `.d.ts` file, but there’s also a default export, which is untyped.

This change fixes it by removing `index.js` altogether. Its only purpose was to re-export everything from `dist/index.js`. This is now handled by pointing the main entrypoint and the default export in `package.json` to `dist/index.js`. The `types` export is necessary, because the file doesn’t exist in the same place as the dist files.

The `module` option was removed entirely. This is a faux ESM option that is supposed to point to a module using ESM syntax. It’s pointing to a CJS file instead, and it would now match the `main` field anyway.