### PR TITLE
docs: text/calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ async function handleDownload() {
         reject(error)
       }
       
-      resolve(new File([value], filename, { type: 'plain/text' }))
+      resolve(new File([value], filename, { type: 'text/calendar' }))
     })
   })
   const url = URL.createObjectURL(file);


### PR DESCRIPTION
I found that the original mimeType could not be opened normally after I downloaded a `.ics` file with the instruction of README. If I use `text/calendar`, it can work.