### PR TITLE
Use `DateTime` type for event exclusion dates

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -112,7 +112,7 @@ export type EventAttributes = {
   uid?: string;
   method?: HeaderAttributes['method'];
   recurrenceRule?: string;
-  exclusionDates?: string;
+  exclusionDates?: DateTime[];
   sequence?: number;
   calName?: HeaderAttributes['calName'];
   classification?: classificationType;


### PR DESCRIPTION
This PR corrects the TypeScript type for the `exclusionDates` property on the `EventAttributes` object. As far as I can tell from looking in `schema/index.js`, all the regular date time formats should be also be valid in the `exclusionDates` array. I was able to successfully use `DateArray`s in an `exclusionDates` array for a project after adding a `// @ts-ignore` directive.

Thanks for maintaining the project!