### PR TITLE
add timezones support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,15 +79,18 @@ export type HeaderAttributes = {
   productId?: string;
   method?: string;
   calName?: string;
+  timezones?: string;
 }
 
 export type EventAttributes = {
   start: DateTime;
   startInputType?: 'local' | 'utc';
   startOutputType?: 'local' | 'utc';
+  startTimezone?: string
 
   endInputType?: 'local' | 'utc';
   endOutputType?: 'local' | 'utc';
+  endTimezone?: string,
 
   title?: string;
   description?: string;
@@ -113,6 +116,7 @@ export type EventAttributes = {
   method?: HeaderAttributes['method'];
   recurrenceRule?: string;
   exclusionDates?: DateTime[];
+  exclusionDatesTimezone?: string;
   sequence?: number;
   calName?: HeaderAttributes['calName'];
   classification?: classificationType;

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -75,7 +75,8 @@ const alarmSchema = yup.object().shape({
 const headerShape = {
   productId: yup.string(),
   method: yup.string(),
-  calName: yup.string()
+  calName: yup.string(),
+  timezones: yup.string().matches(/^BEGIN:VTIMEZONE.*END:VTIMEZONE$/s)
 }
 
 const headerSchema = yup.object().shape(headerShape).noUnknown()
@@ -91,9 +92,11 @@ const eventShape = {
   startType: yup.string().matches(/^(utc|local)$/),
   startInputType: yup.string().matches(/^(utc|local)$/),
   startOutputType: yup.string().matches(/^(utc|local)$/),
+  startTimezone: yup.string(),
   end: dateTimeSchema({ required: false }),
   endInputType: yup.string().matches(/^(utc|local)$/),
   endOutputType: yup.string().matches(/^(utc|local)$/),
+  endTimezone: yup.string(),
   description: yup.string(),
   url: yup.string().matches(urlRegex),
   geo: yup.object().shape({lat: yup.number(), lon: yup.number()}),
@@ -110,6 +113,7 @@ const eventShape = {
   created: dateTimeSchema({ required: false }),
   lastModified: dateTimeSchema({ required: false }),
   exclusionDates: yup.array().of(dateTimeSchema({ required: true })),
+  exclusionDatesTimezone: yup.object().string,
   htmlContent: yup.string()
 }
 

--- a/src/utils/format-tzid-param.js
+++ b/src/utils/format-tzid-param.js
@@ -1,0 +1,3 @@
+export default function formatTzidParam(tzid) {
+  return tzid ? ";TZID=" + tzid : ""
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 import formatDate from './format-date'
+import formatTzidParam from './format-tzid-param'
 import setGeolocation from './set-geolocation'
 import setContact from './set-contact'
 import setOrganizer from './set-organizer'
@@ -12,6 +13,7 @@ import encodeParamValue from './encode-param-value'
 
 export {
   formatDate,
+  formatTzidParam,
   setGeolocation,
   setContact,
   setOrganizer,

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -81,6 +81,13 @@ describe('ics', () => {
         expect(error).to.be.null
         expect(value).to.contain('X-WR-CALNAME:test')
       })
+
+      it('writes timezone information', () => {
+        const timezones = 'BEGIN:VTIMEZONE\r\nTZID:Europe/Zurich\r\nBEGIN:STANDARD\r\nTZNAME:CET\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nDTSTART:19961027T030000\r\nEND:STANDARD\r\nEND:VTIMEZONE';
+        const { error, value } = createEvents([], { timezones })
+        expect(error).to.be.null
+        expect(value).to.contain(timezones + '\r\n')
+      })
     })
 
     describe('when a callback is provided', () => {
@@ -112,6 +119,15 @@ describe('ics', () => {
         createEvents([], { calName: 'test' }, (error, value) => {
           expect(error).to.be.null
           expect(value).to.contain('X-WR-CALNAME:test')
+          done()
+        })
+      })
+
+      it('writes timezone information', (done) => {
+        const timezones = 'BEGIN:VTIMEZONE\r\nTZID:Europe/Zurich\r\nBEGIN:STANDARD\r\nTZNAME:CET\r\nTZOFFSETFROM:+0200\r\nTZOFFSETTO:+0100\r\nDTSTART:19961027T030000\r\nEND:STANDARD\r\nEND:VTIMEZONE';
+        createEvents([], { timezones }, (error, value) => {
+          expect(error).to.be.null
+          expect(value).to.contain(timezones + '\r\n')
           done()
         })
       })

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -187,6 +187,25 @@ describe('pipeline.formatEvent', () => {
     expect(formattedStartEndEvent).to.contain('DTEND;VALUE=DATE:20170518')
   })
 
+  it('writes timezone ids', () => {
+    const event = buildEvent({ 
+      start: [2024, 11, 16], 
+      startTimezone: 'Europe/Zurich', 
+      end: [2024, 11, 16, 19, 54, 32], 
+      endTimezone: 'America/Chicago', 
+      exclusionDates: [
+        [2024, 5, 6, 15, 36, 21],
+        [2024, 7, 21, 9, 38, 7]
+      ],
+      exclusionDatesTimezone: 'Africa/Nairobi' 
+    })
+    const formattedEvent = formatEvent(event)
+    // match against \r\n to ensure times are written in local time (no 'Z' at the end)
+    expect(formattedEvent).to.contain('DTSTART;VALUE=DATE;TZID=Europe/Zurich:20241116\r\n')
+    expect(formattedEvent).to.contain('DTEND;TZID=America/Chicago:20241116T195432\r\n')
+    expect(formattedEvent).to.contain('EXDATE;TZID=Africa/Nairobi:20240506T153621,20240721T093807\r\n')
+  })
+
   it('writes attendees', () => {
     const event = buildEvent({ attendees: [
       {name: 'Adam Gibbons', email: 'adam@example.com'},


### PR DESCRIPTION
- add ability to pass TZIDs to start, end and exclusionDates
- add ability to include time zone definitions in the header. I assume that these are downloaded from elsewhere, therefore they are considered well-formed and are put as-is into the output
- the responsibility to provide time zone information for each time zone used in events is with the user, there is no validation which checks whether there is a VTIMEZONE for each TZID


fixes #198 