### PR TITLE
Add SCHEDULE-AGENT support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,12 +49,15 @@ export type Person = {
   dir?: string;
 };
 
+export type ScheduleAgent = 'SERVER' | 'CLIENT' | 'NONE' | string;
+
 export type Attendee = Person & {
   rsvp?: boolean;
   partstat?: ParticipationStatus;
   role?: ParticipationRole;
   cutype?: ParticipationType;
   xNumGuests?: number;
+  scheduleAgent?: ScheduleAgent;
 };
 
 export type ActionType = 'audio' | 'display' | 'email' | 'procedure';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ics",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ics",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "iCal (ics) file generator",
   "exports": {
     "types": "./index.d.ts",

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -47,6 +47,7 @@ const contactSchema = yup.object().shape({
   dir: yup.string().matches(urlRegex),
   partstat: yup.string(),
   role: yup.string(),
+  scheduleAgent: yup.string().matches(/^(SERVER|CLIENT|NONE)$/),
   cutype: yup.string(),
   xNumGuests: yup.number()
 }).noUnknown()

--- a/src/utils/set-contact.js
+++ b/src/utils/set-contact.js
@@ -1,6 +1,6 @@
 import encodeParamValue from "./encode-param-value";
 
-export default function setContact({ name, email, rsvp, dir, partstat, role, cutype, xNumGuests }) {
+export default function setContact({ name, email, rsvp, dir, partstat, role, cutype, xNumGuests, scheduleAgent }) {
   let formattedParts = [];
 
   if(rsvp !== undefined){
@@ -20,6 +20,9 @@ export default function setContact({ name, email, rsvp, dir, partstat, role, cut
   }
   if(dir){
     formattedParts.push("DIR=".concat(encodeParamValue(dir)));
+  }
+  if(scheduleAgent){
+    formattedParts.push("SCHEDULE-AGENT=".concat(encodeParamValue(scheduleAgent)));
   }
   formattedParts.push('CN='.concat((encodeParamValue(name || 'Unnamed attendee'))));
 

--- a/test/utils/set-contact.spec.js
+++ b/test/utils/set-contact.spec.js
@@ -73,4 +73,27 @@ describe('utils.setContact', () => {
     expect(contactString).to.contain('CUTYPE="INDIVIDUAL"')
     expect(contactString).to.contain('X-NUM-GUESTS=0')
   })
+  it('set a contact with schedule-agent', () => {
+    const contact = { name: 'm-vinc', email: 'vinc@example.com' }
+    const contactUndefined = Object.assign({scheduleAgent: undefined}, contact)
+    const contactServer = Object.assign({scheduleAgent: 'SERVER'}, contact)
+    const contactClient = Object.assign({scheduleAgent: 'CLIENT'}, contact)
+    const contactNone = Object.assign({scheduleAgent: 'NONE'}, contact)
+    const contactXCustom = Object.assign({scheduleAgent: 'X-CUSTOM'}, contact)
+
+    expect(setContact(contactUndefined))
+    .to.equal('CN="m-vinc":mailto:vinc@example.com')
+
+    expect(setContact(contactServer))
+    .to.equal('SCHEDULE-AGENT="SERVER";CN="m-vinc":mailto:vinc@example.com')
+
+    expect(setContact(contactClient))
+    .to.equal('SCHEDULE-AGENT="CLIENT";CN="m-vinc":mailto:vinc@example.com')
+
+    expect(setContact(contactNone))
+    .to.equal('SCHEDULE-AGENT="NONE";CN="m-vinc":mailto:vinc@example.com')
+
+    expect(setContact(contactXCustom))
+    .to.equal('SCHEDULE-AGENT="X-CUSTOM";CN="m-vinc":mailto:vinc@example.com')
+  })
 })


### PR DESCRIPTION
This parameter is required for applications such as Cal.com to not trigger built-in calendar attendee invite emails.

Relevant: https://github.com/calcom/cal.com/pull/21095

For Cal.com I created a patch for `v2.37.0`: https://github.com/rijx/ics2/commit/a2d1320219007524a14fa6c9af7aaa6f32ba0dea

It would be interesting to consider patching all versions with this.

@adamgibbons Could you please recommend how you would like to see this integrated?
