### PR TITLE
Escape TEXT special characters in VALARM summary and description

### DIFF
--- a/src/utils/set-alarm.js
+++ b/src/utils/set-alarm.js
@@ -1,6 +1,8 @@
 import formatDate from './format-date'
 import foldLine from './fold-line'
 import encodeNewLines from './encode-new-lines'
+import setSummary from './set-summary'
+import setDescription from './set-description'
 
 function setDuration ({
   weeks,
@@ -51,12 +53,12 @@ export default function setAlarm(attributes = {}) {
   let formattedString = 'BEGIN:VALARM\r\n'
   formattedString += foldLine(`ACTION:${encodeNewLines(setAction(action))}`) + '\r\n'
   formattedString += repeat ? foldLine(`REPEAT:${repeat}`) + '\r\n' : ''
-  formattedString += description ? foldLine(`DESCRIPTION:${encodeNewLines(description)}`) + '\r\n' : ''
+  formattedString += description ? foldLine(`DESCRIPTION:${encodeNewLines(setDescription(description))}`) + '\r\n' : ''
   formattedString += duration ? foldLine(`DURATION:${setDuration(duration)}`) + '\r\n' : ''
   let attachInfo = attachType ? attachType : 'FMTTYPE=audio/basic'
   formattedString += attach ? foldLine(encodeNewLines(`ATTACH;${attachInfo}:${attach}`)) + '\r\n' : ''
   formattedString += trigger ? (setTrigger(trigger)) : ''
-  formattedString += summary ? (foldLine(`SUMMARY:${encodeNewLines(summary)}`) + '\r\n') : ''
+  formattedString += summary ? (foldLine(`SUMMARY:${encodeNewLines(setSummary(summary))}`) + '\r\n') : ''
   formattedString += 'END:VALARM\r\n'
 
   return formattedString

--- a/test/utils/set-alarm.spec.js
+++ b/test/utils/set-alarm.spec.js
@@ -32,6 +32,17 @@ describe('utils.setAlarm', () => {
       ``
     ].join('\r\n'))
   })
+
+  it('escapes TEXT special characters in description and summary', () => {
+    const alarm = setAlarm({
+      action: 'display',
+      trigger: [1997, 2, 17, 6, 30],
+      description: 'Buy milk, eggs; pay \\ now',
+      summary: 'A; B, C'
+    })
+    expect(alarm).to.contain('DESCRIPTION:Buy milk\\, eggs\\; pay \\\\ now')
+    expect(alarm).to.contain('SUMMARY:A\\; B\\, C')
+  })
 })
 
 // BEGIN:VALARM


### PR DESCRIPTION
In `setAlarm`, the `SUMMARY` and `DESCRIPTION` properties run through `encodeNewLines` only, so backslashes, semicolons and commas in alarm text are emitted unescaped.

The matching VEVENT properties already escape these. In `src/pipeline/format.js` the event wraps them in `setSummary` / `setDescription` (which call `formatText`):

```js
icsFormat += title ? foldLine(`SUMMARY:${encodeNewLines(setSummary(title))}`) + '\r\n' : ''
...
icsFormat += description ? (foldLine(`DESCRIPTION:${encodeNewLines(setDescription(description))}`) + '\r\n') : ''
```

RFC 5545 §3.3.11 requires TEXT values to escape `\`, `;`, `,` and newlines, and `SUMMARY` / `DESCRIPTION` are TEXT in a VALARM just like in a VEVENT. So an alarm description such as `Buy milk, eggs; pay \ now` currently produces an unescaped, ambiguous line that strict parsers can misread.

This routes the alarm's summary and description through the same `setSummary` / `setDescription` helpers the event uses, so both code paths escape TEXT identically. Added a test covering the special characters.
